### PR TITLE
Add GPU-accelerated metadynamics method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,12 @@ include_directories("${PROJECT_BINARY_DIR}")
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/schema/)
 add_definitions(${MPI_CXX_COMPILE_FLAGS})
 
+option(SSAGES_GPU_ENABLED "Enable GPU acceleration" OFF)
+if(SSAGES_GPU_ENABLED)
+    enable_language(CUDA)
+    add_definitions(-DSSAGES_GPU_ENABLED)
+endif()
+
 # General source files
 set(SOURCE
     src/Methods/ABF.cpp
@@ -80,6 +86,10 @@ set(SOURCE
     src/ResourceHandler.cpp
     "include/nnet/nnet.cpp"
 )
+
+if(SSAGES_GPU_ENABLED)
+    list(APPEND SOURCE src/Methods/MetaGPU.cu)
+endif()
 
 ####################### MD ENGINES #########################
 
@@ -130,6 +140,11 @@ elseif (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
 else ()
     set_target_properties(libssages PROPERTIES COMPILE_FLAGS "-O3 -fPIC")
 endif ()
+
+if(SSAGES_GPU_ENABLED)
+    find_package(CUDA REQUIRED)
+    target_link_libraries(libssages ${CUDA_CUDART_LIBRARY})
+endif()
 
 # Set C++ standard - default to C++11 but allow override for modern GROMACS
 if(NOT DEFINED CMAKE_CXX_STANDARD)

--- a/src/Methods/Meta.h
+++ b/src/Methods/Meta.h
@@ -65,63 +65,63 @@ namespace SSAGES
 	 *
 	 * \ingroup Methods
 	 */
-	class Meta : public Method
-	{
-	private:	
-		//! Hills.
-		std::vector<Hill> hills_;
+        class Meta : public Method
+        {
+        protected:
+                //! Hills.
+                std::vector<Hill> hills_;
 
-		//! Hill height.
-		double height_;
+                //! Hill height.
+                double height_;
 
-		//! Hill widths.
-		std::vector<double> widths_;
+                //! Hill widths.
+                std::vector<double> widths_;
 
-		//!@{
-		//! Derivatives and temporary storage vectors.
-		std::vector<double> derivatives_, tder_, dx_;
-		//!@}
+                //!@{
+                //! Derivatives and temporary storage vectors.
+                std::vector<double> derivatives_, tder_, dx_;
+                //!@}
 
-		//! Frequency of new hills
-		unsigned int hillfreq_;
+                //! Frequency of new hills
+                unsigned int hillfreq_;
 
-		//! CV Grid. 
-		Grid<Vector>* grid_;
+                //! CV Grid.
+                Grid<Vector>* grid_;
 
-		//!@{
-		//! Bounds 
-		std::vector<double> upperb_, lowerb_;
-		//!@}
+                //!@{
+                //! Bounds
+                std::vector<double> upperb_, lowerb_;
+                //!@}
 
-		//!@{
-		//! Bound restraints. 
-		std::vector<double> upperk_, lowerk_;
-		//!@}
+                //!@{
+                //! Bound restraints.
+                std::vector<double> upperk_, lowerk_;
+                //!@}
 
-		//! Adds a new hill.
-		/*!
-		 * \param cvs List of CVs.
-		 * \param iteration Current iteration.
-		 */
-		void AddHill(const CVList& cvs, int iteration);
+                //! Adds a new hill.
+                /*!
+                 * \param cvs List of CVs.
+                 * \param iteration Current iteration.
+                 */
+                void AddHill(const CVList& cvs, int iteration);
 
-		//! Computes the bias force.
-		/*!
-		 * \param cvs List of CVs.
-		 */
-		void CalcBiasForce(const CVList& cvs);
+                //! Computes the bias force.
+                /*!
+                 * \param cvs List of CVs.
+                 */
+                virtual void CalcBiasForce(const CVList& cvs);
 
-		//! Prints the new hill to file
-		/*!
-		 * \param hill Hill to be printed.
-		 * \param iteration Current iteration.
-		 */
-		void PrintHill(const Hill& hill, int iteration);
+                //! Prints the new hill to file
+                /*!
+                 * \param hill Hill to be printed.
+                 * \param iteration Current iteration.
+                 */
+                void PrintHill(const Hill& hill, int iteration);
 
-		//! Output stream for hill data.
-		std::ofstream hillsout_;
+                //! Output stream for hill data.
+                std::ofstream hillsout_;
 
-	public:
+        public:
 		//! Constructor
 		/*!
 		 * \param world MPI global communicator.

--- a/src/Methods/MetaGPU.cu
+++ b/src/Methods/MetaGPU.cu
@@ -1,0 +1,109 @@
+#include "MetaGPU.h"
+#ifdef SSAGES_GPU_ENABLED
+#include <cuda_runtime.h>
+#include <vector>
+#include <cmath>
+
+namespace SSAGES {
+__device__ double gpu_gaussian(double dx, double sigma) {
+    return exp(-0.5 * dx * dx / (sigma * sigma));
+}
+
+__device__ double gpu_gaussian_deriv(double dx, double sigma) {
+    return (-dx / (sigma * sigma)) * exp(-0.5 * dx * dx / (sigma * sigma));
+}
+
+__global__ void meta_bias_kernel(const double* cv,
+                                 const double* centers,
+                                 const double* widths,
+                                 const double* heights,
+                                 int ncv,
+                                 int nhills,
+                                 double* derivatives) {
+    int i = threadIdx.x;
+    if (i < ncv)
+        derivatives[i] = 0.0;
+    __syncthreads();
+
+    for (int h = 0; h < nhills; ++h) {
+        double dx[8];
+        double tbias = 1.0;
+        for (int j = 0; j < ncv; ++j) {
+            dx[j] = cv[j] - centers[h * ncv + j];
+            tbias *= gpu_gaussian(dx[j], widths[h * ncv + j]);
+        }
+        for (int j = 0; j < ncv; ++j) {
+            double term = heights[h];
+            for (int k = 0; k < ncv; ++k) {
+                if (k == j)
+                    term *= gpu_gaussian_deriv(dx[k], widths[h * ncv + k]);
+                else
+                    term *= gpu_gaussian(dx[k], widths[h * ncv + k]);
+            }
+            atomicAdd(&derivatives[j], term);
+        }
+    }
+}
+
+MetaGPUAccelerated* MetaGPUAccelerated::Build(const Json::Value& json,
+                                              const MPI_Comm& world,
+                                              const MPI_Comm& comm,
+                                              const std::string& path) {
+    Meta* base = Meta::Build(json, world, comm, path);
+    auto* derived = new MetaGPUAccelerated(*base);
+    delete base;
+    return derived;
+}
+
+void MetaGPUAccelerated::CalcBiasForce(const CVList& cvs) {
+    auto n = cvs.size();
+    size_t nhills = hills_.size();
+    std::fill(derivatives_.begin(), derivatives_.end(), 0.0);
+    if (n == 0 || nhills == 0)
+        return;
+
+    std::vector<double> cv(n);
+    for (size_t i = 0; i < n; ++i)
+        cv[i] = cvs[i]->GetValue();
+
+    std::vector<double> centers(nhills * n), widths(nhills * n), heights(nhills);
+    for (size_t h = 0; h < nhills; ++h) {
+        for (size_t j = 0; j < n; ++j) {
+            centers[h * n + j] = hills_[h].center[j];
+            widths[h * n + j] = hills_[h].width[j];
+        }
+        heights[h] = hills_[h].height;
+    }
+
+    double *d_cv, *d_centers, *d_widths, *d_heights, *d_derivatives;
+    cudaMalloc(&d_cv, n * sizeof(double));
+    cudaMalloc(&d_centers, nhills * n * sizeof(double));
+    cudaMalloc(&d_widths, nhills * n * sizeof(double));
+    cudaMalloc(&d_heights, nhills * sizeof(double));
+    cudaMalloc(&d_derivatives, n * sizeof(double));
+
+    cudaMemcpy(d_cv, cv.data(), n * sizeof(double), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_centers, centers.data(), nhills * n * sizeof(double), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_widths, widths.data(), nhills * n * sizeof(double), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_heights, heights.data(), nhills * sizeof(double), cudaMemcpyHostToDevice);
+
+    meta_bias_kernel<<<1, n>>>(d_cv, d_centers, d_widths, d_heights, n, nhills, d_derivatives);
+    cudaMemcpy(derivatives_.data(), d_derivatives, n * sizeof(double), cudaMemcpyDeviceToHost);
+
+    cudaFree(d_cv);
+    cudaFree(d_centers);
+    cudaFree(d_widths);
+    cudaFree(d_heights);
+    cudaFree(d_derivatives);
+
+    for (size_t i = 0; i < n; ++i) {
+        auto cval = cvs[i]->GetValue();
+        if (cval < lowerb_[i])
+            derivatives_[i] += lowerk_[i] * (cval - lowerb_[i]);
+        else if (cval > upperb_[i])
+            derivatives_[i] += upperk_[i] * (cval - upperb_[i]);
+    }
+}
+
+} // namespace SSAGES
+#endif

--- a/src/Methods/MetaGPU.h
+++ b/src/Methods/MetaGPU.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Meta.h"
+#ifdef SSAGES_GPU_ENABLED
+#include <json/json.h>
+
+namespace SSAGES {
+class MetaGPUAccelerated : public Meta {
+public:
+    using Meta::Meta;
+    MetaGPUAccelerated(const Meta& other) : Meta(other) {}
+
+    static MetaGPUAccelerated* Build(const Json::Value& json,
+                                     const MPI_Comm& world,
+                                     const MPI_Comm& comm,
+                                     const std::string& path);
+protected:
+    void CalcBiasForce(const CVList& cvs) override;
+};
+}
+#endif

--- a/src/Methods/Method.cpp
+++ b/src/Methods/Method.cpp
@@ -27,6 +27,7 @@
 #include "StringMethod.h"
 #ifdef SSAGES_GPU_ENABLED
 #include "UmbrellaGPU.h"
+#include "MetaGPU.h"
 #endif
 #include "schema.h"
 #include "json/json.h"
@@ -69,16 +70,18 @@ namespace SSAGES
 			method = CFF::Build(json, world, comm, path);
 		else if(json["type"] == "ForwardFlux")
 			method = ForwardFlux::Build(json, world, comm, path);
-		else if(json["type"] == "Metadynamics")
-			method = Meta::Build(json, world, comm, path);
-		else if(json["type"] == "Umbrella")
-			method = Umbrella::Build(json, world, comm, path);
+                else if(json["type"] == "Metadynamics")
+                        method = Meta::Build(json, world, comm, path);
+                else if(json["type"] == "Umbrella")
+                        method = Umbrella::Build(json, world, comm, path);
 #ifdef SSAGES_GPU_ENABLED
-		else if(json["type"] == "UmbrellaGPUAccelerated")
-			method = UmbrellaGPUAccelerated::Build(json, world, comm, path);
+                else if(json["type"] == "UmbrellaGPUAccelerated")
+                        method = UmbrellaGPUAccelerated::Build(json, world, comm, path);
+                else if(json["type"] == "MetadynamicsGPUAccelerated")
+                        method = MetaGPUAccelerated::Build(json, world, comm, path);
 #endif
-		else if(json["type"] == "String")
-			method = StringMethod::Build(json, world, comm, path);
+                else if(json["type"] == "String")
+                        method = StringMethod::Build(json, world, comm, path);
 		else
 			throw std::invalid_argument(path + ": Unknown method type specified.");
 

--- a/test_meta_gpu.json
+++ b/test_meta_gpu.json
@@ -1,0 +1,25 @@
+{
+  "schema": "http://ssagesproject.github.io/ssages/schemas/schema.json",
+  "walkers": 1,
+  "input": [{"walker": 0, "args": "-s test.tpr -deffnm test"}],
+  "CVs": [{
+    "type": "ParticleSeparation",
+    "name": "distance",
+    "group1": [1],
+    "group2": [2],
+    "fixx": true
+  }],
+  "methods": [{
+    "type": "MetadynamicsGPUAccelerated",
+    "widths": [0.1],
+    "height": 1.0,
+    "lower_bounds": [0.0],
+    "upper_bounds": [5.0],
+    "lower_bound_restraints": [100.0],
+    "upper_bound_restraints": [100.0],
+    "hill_frequency": 10,
+    "frequency": 1,
+    "use_gpu": true
+  }],
+  "logger": {"frequency": 100, "file": "test_meta_gpu.log"}
+}


### PR DESCRIPTION
## Summary
- enable optional GPU build and link against CUDA
- expose metadynamics internals for extension
- implement `MetadynamicsGPUAccelerated` with CUDA kernel for bias forces
- add sample GPU metadynamics JSON configuration

## Testing
- `cmake ..` *(fails: Could NOT find MPI (missing: MPI_C_FOUND MPI_CXX_FOUND))*

------
https://chatgpt.com/codex/tasks/task_e_689cb1c44020832b85f7790015d17419